### PR TITLE
Add provenance to kustomize

### DIFF
--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -10,7 +10,7 @@ function install_kustomize() {
   KSOPS_VERSION=$(git rev-parse HEAD)
   KSOPS_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || true )
   LDFLAGS="-X sigs.k8s.io/kustomize/api/provenance.buildDate=${BUILD_DATE}"
-  LDFLAGS+=" -X sigs.k8s.io/kustomize/api/provenance.gitCommit=$(curl --silent 'https://api.github.com/repos/kubernetes-sigs/kustomize/commits?sha=kustomize/v3.8.0' | jq -r '.[0].sha')"
+  LDFLAGS+=" -X sigs.k8s.io/kustomize/api/provenance.gitCommit=v3@${KUSTOMIZE_VERSION}"
   if [ ! -z $KSOPS_TAG ]; then
     KSOPS_VERSION=$KSOPS_TAG
   fi

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -5,7 +5,17 @@ KUSTOMIZE="kustomize"
 
 function install_kustomize() {
   echo "Installing $KUSTOMIZE..."
-  GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v3.8.0
+  KUSTOMIZE_VERSION='v3.8.0'
+  BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  KSOPS_VERSION=$(git rev-parse HEAD)
+  KSOPS_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || true )
+  LDFLAGS="-X sigs.k8s.io/kustomize/api/provenance.buildDate=${BUILD_DATE}"
+  LDFLAGS+=" -X sigs.k8s.io/kustomize/api/provenance.gitCommit=$(curl --silent 'https://api.github.com/repos/kubernetes-sigs/kustomize/commits?sha=kustomize/v3.8.0' | jq -r '.[0].sha')"
+  if [ ! -z $KSOPS_TAG ]; then
+    KSOPS_VERSION=$KSOPS_TAG
+  fi
+  LDFLAGS+=" -X sigs.k8s.io/kustomize/api/provenance.version=${KUSTOMIZE_VERSION}+ksops.${KSOPS_VERSION}"
+  GO111MODULE=on go get -ldflags "${LDFLAGS}" sigs.k8s.io/kustomize/kustomize/v3@$KUSTOMIZE_VERSION
 
   echo "Successfully installed $KUSTOMIZE!"
   kustomize version
@@ -31,4 +41,3 @@ else
     # Install
     install_kustomize
 fi
-


### PR DESCRIPTION
Fixes #46 

###Example:
```
└─▶ kustomize version
{Version:v3.8.0+ksops.8a8912c5df6b60ed409ba1555cf755bb9c973cb9 GitCommit:v3@v3.8.0 BuildDate:2020-07-11T16:45:48Z GoOs:darwin GoArch:amd64}
└─▶ kustomize version --short
{v3.8.0+ksops.8a8912c5df6b60ed409ba1555cf755bb9c973cb9  2020-07-11T16:45:48Z  }

## tag

─▶ kustomize version
{Version:v3.8.0+ksops.v2.1.2 GitCommit:v3@v3.8.0 BuildDate:2020-07-11T16:45:48Z GoOs:darwin GoArch:amd64}
└─▶ kustomize version --short
{v3.8.0+ksops.v2.1.2  2020-07-11T16:48:48Z  }

```

The Version is the version of kustomize with semvar meta recognizing the kustomize-sops version. If the kustomize-sops is a tag it will be the tag, else its the sha.

The GitCommit I took some liberty with, and set it to the go get version used. I don't know if that's the best option, but it gvies some details as to the versions of the build.