### PR TITLE
Remove Support for go 1.13

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        go: [1.13, 1.14]
+        os: [ubuntu-latest]
+        go: [1.14]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/viaduct-ai/kustomize-sops
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.53.0 // indirect


### PR DESCRIPTION
### Description
- Update go.mod to 1.14
- Remove go 1.13 from CI
- Also remove MacOSX from CI