### PR TITLE
Script for Downloading and Installing the Latest KSOPS Exec Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ At [Viaduct](https://www.viaduct.ai/), we manage our Kubernetes resources via th
 
 KSOPS was originally developed as a [kustomize Go plugin](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#go-plugins). Up until *v2.2.0* this was the only installation option. To install, follow steps 0-3 of the [Getting Started section](#getting-started) and then run `make install`.
 
-### [Experimental] Exec Plugin 
+### Exec Plugin
 
 [kustomize exec plugins](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#exec-plugins) offers a simpler installation and dependency management alternative to [kustomize Go plugin](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#go-plugins) at the cost of debugability (error messages are swallowed). By popular demand, we now offer support for KSOPS as a kustomize exec plugin.
 
@@ -47,21 +47,30 @@ apiVersion: viaduct.ai/v1
 kind: ksops-exec
 ```
 
-Alternatively, you can choose to switch over entirely to the exec plugin by running 
+Alternatively, you can choose to switch over entirely to the exec plugin by running one of the following commands:
+
+
+#### Remotely Download the Latest Release
+```bash
+# Verify the $XDG_CONFIG_HOME environment variable exists then run
+source <(curl -s https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh)
+```
+
+#### Run `make install-exec-only` with the Cloned Repo Locally
 
 ```bash
 # install exec plugin under ksops
 make install-exec-only
 ```
 
-This will install the exec plugin under both `ksops` and `ksops-exec`, so your existing generator manifests will use the exec plugin.
+These will install the exec plugin under both `ksops` and `ksops-exec`, so your existing generator manifests will use the exec plugin.
 
 Please provide feedback, ideas, and make an issue if you have questions or run into issues!
 
 
 ## Getting Started
 
-### 0. Verify Requirements  
+### 0. Verify Requirements
 Before continuing, verify your installation of [Go](https://github.com/golang/go), [SOPS](https://github.com/mozilla/sops), and `gpg`. Below are a few non-comprehensive commands to quickly check your installations:
 
 ```bash
@@ -234,7 +243,7 @@ kind: Secret
 metadata:
   name: argocd-secret
   annotations:
-      # replace the base secret data/stringData values with these encrypted data/stringData values 
+      # replace the base secret data/stringData values with these encrypted data/stringData values
       kustomize.config.k8s.io/behavior: replace
 type: Opaque
 data:
@@ -251,7 +260,7 @@ kind: Secret
 metadata:
   name: argocd-secret
   annotations:
-      # merge the base secret data/stringData values with these encrypted data/stringData values 
+      # merge the base secret data/stringData values with these encrypted data/stringData values
       kustomize.config.k8s.io/behavior: merge
 type: Opaque
 data:

--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# Require $XDG_CONFIG_HOME to be set
+if [[ -z "$XDG_CONFIG_HOME" ]]; then
+  echo "You must define XDG_CONFIG_HOME to use a kustomize plugin"
+  echo "Add 'export XDG_CONFIG_HOME=\$HOME/.config' to your .bashrc or .zshrc"
+  exit 1
+fi
+
+
+PLUGIN_PATH="$XDG_CONFIG_HOME/kustomize/plugin/viaduct.ai/v1/ksops/"
+
+
+echo "Verify ksops plugin directory exists and is empty"
+rm -rf $PLUGIN_PATH || true
+mkdir -p $PLUGIN_PATH
+
+ARCH=$(uname -m)
+OS=""
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    OS="Linux"
+    ;;
+  darwin*)
+    OS="Darwin"
+    ;;
+  msys*)
+    OS="Windows"
+    ;;
+  windowsnt*)
+    OS="Windows"
+    ;;
+  *)
+    echo "Unknown OS type: $(uname)"
+    echo "Please consider contributing to this script to support your OS."
+    exit 1
+    ;;
+esac
+
+
+echo "Downloading latest release to ksops plugin path"
+wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -xz -C $PLUGIN_PATH
+echo "Successfully installed ksops"

--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -10,11 +10,14 @@ fi
 
 
 PLUGIN_PATH="$XDG_CONFIG_HOME/kustomize/plugin/viaduct.ai/v1/ksops/"
+EXEC_PLUGIN_PATH="$XDG_CONFIG_HOME/kustomize/plugin/viaduct.ai/v1/ksops-exec/"
 
 
 echo "Verify ksops plugin directory exists and is empty"
 rm -rf $PLUGIN_PATH || true
+rm -rf $EXEC_PLUGIN_PATH || true
 mkdir -p $PLUGIN_PATH
+mkdir -p $EXEC_PLUGIN_PATH
 
 ARCH=$(uname -m)
 OS=""
@@ -41,4 +44,5 @@ esac
 
 echo "Downloading latest release to ksops plugin path"
 wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -xz -C $PLUGIN_PATH
+cp  $PLUGIN_PATH* $EXEC_PLUGIN_PATH
 echo "Successfully installed ksops"

--- a/scripts/install-ksops.sh
+++ b/scripts/install-ksops.sh
@@ -4,7 +4,7 @@ set -e
 # Require $XDG_CONFIG_HOME to be set
 if [[ -z "$XDG_CONFIG_HOME" ]]; then
   echo "You must define XDG_CONFIG_HOME to use a kustomize plugin"
-  echo "Add 'export XDG_CONFIG_HOME=\$HOME/.config' to your .bashrc"
+  echo "Add 'export XDG_CONFIG_HOME=\$HOME/.config' to your .bashrc or .zshrc"
   exit 1
 fi
 


### PR DESCRIPTION
Relates to https://github.com/viaduct-ai/kustomize-sops/issues/61

### Description

This adds a script with instructions for downloading the latest KSOPS exec plugin, making it much simpler to onboard the KSOPS (exec) plugin.

- Adds the new install option to the Exec Plugin REAMDE section
- Also removes `[Experimental]` flag from the exec plugin (no one has reported any issues)  