### PR TITLE
Publish Images to Quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,9 @@ dockers:
       - "viaductoss/{{ .ProjectName }}:latest"
       - "viaductoss/{{ .ProjectName }}:{{ .Tag }}"
       - "viaductoss/{{ .ProjectName }}:v{{ .Major }}"
+      - "quay.io/viaductoss/{{ .ProjectName }}:latest"
+      - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}"
+      - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}"
 
     # Template of the docker build flags.
     build_flag_templates:
@@ -74,11 +77,11 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files:
-    - go.mod
-    - go.sum
-    - Makefile
-    - scripts/
-    - exec_plugin.go
-    - ksops.go
-    # include .git for version
-    - .git/
+      - go.mod
+      - go.sum
+      - Makefile
+      - scripts/
+      - exec_plugin.go
+      - ksops.go
+      # include .git for version
+      - .git/

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ make test
 
 
 [KSOPS Docker Image](https://hub.docker.com/r/viaductoss/ksops)
+[KSOPS Quay.io Image](https://quay.io/repository/viaductoss/ksops)
 
 ### Enable Kustomize Plugins via Argo CD ConfigMap
 As of now to allow [Argo CD](https://github.com/argoproj/argo-cd/) to use [kustomize](https://github.com/kubernetes-sigs/kustomize/) plugins you must use the `enable_alpha_plugins` flag. This is configured by the `kustomize.buildOptions` setting in the [Argo CD](https://github.com/argoproj/argo-cd/) ConfigMap

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ make test
 
 
 [KSOPS Docker Image](https://hub.docker.com/r/viaductoss/ksops)
+
 [KSOPS Quay.io Image](https://quay.io/repository/viaductoss/ksops)
 
 ### Enable Kustomize Plugins via Argo CD ConfigMap


### PR DESCRIPTION
Closes https://github.com/viaduct-ai/kustomize-sops/issues/86

### Description

> With docker's new rate-limiting policies, we're seeing more organizations offer non docker alternatives to source their images.

- Authenticates to Quay.io in release CI
- Add Quay.io to image release templates

https://quay.io/repository/viaductoss/ksops

I'll test with the next release