### PR TITLE
modify the configmap data for argocd

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-  kustomize.buildOptions: "--enable_alpha_plugins"
+  # For KSOPs versions < v2.5.0, use the old kustomize flag style
+  # kustomize.buildOptions: "--enable_alpha_plugins"
+  kustomize.buildOptions: "--enable-alpha-plugins"
 ```
 
 ### KSOPS Repo Sever Patch

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-  kustomize.buildOptions: "--enable-alpha-plugins"
+  kustomize.buildOptions: "--enable_alpha_plugins"
 ```
 
 ### KSOPS Repo Sever Patch


### PR DESCRIPTION
If the configmap data is `--enable-alpha-plugins` instead of `--enable_alpha_plugins`,will show error ```Unable to create application: application spec is invalid: InvalidSpecError: Unable to get app details: rpc error: code = Unknown desc = `kustomize build /tmp/https:__github.ibm.com_crmk8sdevops_devops4newco/helm-charts/kustomize/apim/overlays/svt --enable-alpha-plugins` failed exit status 1: Error: unknown flag: --enable-alpha-plugins``` when using kops with argocd.