### PR TITLE
report errors on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ KSOPS was originally developed as a [kustomize Go plugin](https://kubernetes-sig
 
 ### Exec Plugin
 
-[kustomize exec plugins](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#exec-plugins) offers a simpler installation and dependency management alternative to [kustomize Go plugin](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#go-plugins) at the cost of debugability (error messages are swallowed). By popular demand, we now offer support for KSOPS as a kustomize exec plugin.
+[kustomize exec plugins](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#exec-plugins) offers a simpler installation and dependency management alternative to [kustomize Go plugin](https://kubernetes-sigs.github.io/kustomize/guides/plugins/#go-plugins). By popular demand, we now offer support for KSOPS as a kustomize exec plugin.
 
 Currently, the new KSOPS exec plugin is opt-in. It is installed as a new plugin, `ksops-exec`, when you run `make install`. To switch a manifest to use the new exec plugin, you can simply change the `kind` in the generator manifest.
 

--- a/exec_plugin.go
+++ b/exec_plugin.go
@@ -18,17 +18,16 @@ type ksops struct {
 // main executes KOSPS as an exec plugin
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Println("received too few args:", os.Args)
-		fmt.Println("always invoke this via kustomize plugins")
+		fmt.Fprintln(os.Stderr, "received too few args:", os.Args)
+		fmt.Fprintln(os.Stderr, "always invoke this via kustomize plugins")
 		os.Exit(1)
 	}
 
 	// ignore the first file name argument
 	// load the second argument, the file path
 	content, err := ioutil.ReadFile(os.Args[1])
-
 	if err != nil {
-		fmt.Println("unable to read in manifest", os.Args[1])
+		fmt.Fprintln(os.Stderr, "unable to read in manifest", os.Args[1])
 		os.Exit(1)
 	}
 
@@ -36,12 +35,12 @@ func main() {
 	err = yaml.Unmarshal(content, &manifest)
 
 	if err != nil {
-		fmt.Printf("error unmarshalling manifest content: %q \n%s\n", err, content)
+		fmt.Fprintf(os.Stderr, "error unmarshalling manifest content: %q \n%s\n", err, content)
 		os.Exit(1)
 	}
 
 	if manifest.Files == nil {
-		fmt.Println("missing the required 'files' key in the ksops manifests")
+		fmt.Fprintln(os.Stderr, "missing the required 'files' key in the ksops manifests")
 		os.Exit(1)
 	}
 
@@ -49,17 +48,15 @@ func main() {
 
 	for _, file := range manifest.Files {
 		b, err := ioutil.ReadFile(file)
-
 		if err != nil {
-			fmt.Printf("error reading %q: %q\n", file, err.Error())
+			fmt.Fprintf(os.Stderr, "error reading %q: %q\n", file, err.Error())
 			os.Exit(1)
 		}
 
 		format := formats.FormatForPath(file)
 		data, err := decrypt.DataWithFormat(b, format)
-
 		if err != nil {
-			fmt.Printf("trouble decrypting file %s", err.Error())
+			fmt.Fprintf(os.Stderr, "trouble decrypting file %s", err.Error())
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
before:

```sh
$ kustomize build --enable-alpha-plugins
Error: failure in plugin configured via /var/folders/bd/c0ry13mx2t194zdq7ff2z3_r0000gp/T/kust-plugin-config-929531124; exit status 1: exit status 1
```

after

```sh
$ kustomize build --enable-alpha-plugins
error reading "./secret.enc.yaml": "open ./secret.enc.yaml: no such file or directory"
Error: failure in plugin configured via /var/folders/bd/c0ry13mx2t194zdq7ff2z3_r0000gp/T/kust-plugin-config-426771182; exit status 1: exit status 1
```