### PR TITLE
Remove backslash on missing env suggestion.

### DIFF
--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -4,7 +4,7 @@ set -e
 # Require $XDG_CONFIG_HOME to be set
 if [[ -z "$XDG_CONFIG_HOME" ]]; then
   echo "You must define XDG_CONFIG_HOME to use a kustomize plugin"
-  echo "Add 'export XDG_CONFIG_HOME=\$HOME/.config' to your .bashrc or .zshrc"
+  echo "Add 'export XDG_CONFIG_HOME=$HOME/.config' to your .bashrc or .zshrc"
   exit 1
 fi
 


### PR DESCRIPTION
If you add the export as suggested with a backslash, it causes the plugin to install in the current directory under a "$HOME" directory, instead of the real user $HOME directory.