### PR TITLE
Update kustomize to v4.3.0

### DIFF
--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -6,7 +6,7 @@ KUSTOMIZE="kustomize"
 function install_kustomize() {
   echo "Installing $KUSTOMIZE..."
   KUSTOMIZE_MAJOR_VERSION='v4'
-  KUSTOMIZE_VERSION="${KUSTOMIZE_MAJOR_VERSION}.2.0"
+  KUSTOMIZE_VERSION="${KUSTOMIZE_MAJOR_VERSION}.3.0"
   BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
   KSOPS_VERSION=$(git rev-parse HEAD)
   KSOPS_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || true )


### PR DESCRIPTION
### Description

Old habits die hard. This is no longer needed because of #127, but still want to update the install script to [kustomize v4.3.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.3.0)