### PR TITLE
feat(install-ksops-archive): Support Git-Bash install

### DIFF
--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -8,6 +8,14 @@ if [[ -z "$XDG_CONFIG_HOME" ]]; then
   exit 1
 fi
 
+req_cmds_lst=( "wget" )
+# Require CLI tools to be available
+for i in "${req_cmds_lst[@]}" ;do
+  if ! which "${i}" &> /dev/null ;then
+    echo "Required utility not found in PATH: '${i}'"
+    exit 1
+  fi
+done
 
 PLUGIN_PATH="$XDG_CONFIG_HOME/kustomize/plugin/viaduct.ai/v1/ksops/"
 
@@ -31,7 +39,10 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
   windowsnt*)
     OS="Windows"
     ;;
-  *)
+  mingw64_nt*)
+    OS="Windows"
+    ;;
+  ,*)
     echo "Unknown OS type: $(uname)"
     echo "Please consider contributing to this script to support your OS."
     exit 1


### PR DESCRIPTION
### Enhancement 

Sub-Type: Extending Support to Additional Platform/Use-Case

### Summary
Enable KSops install procedure from Git-Bash on Win10

### Description
- Add the `uname` of the Git-Bash shell to the install script.
- Add explicit failure on required `wget` for clarity, (mostly benefiting non-*Nix system)