### PR TITLE
feat: allow multiple options for install,

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ source $HOME/.zshrc
 
 ### Install the Latest Release
 
+Using curl
 ```bash
 # Verify the $XDG_CONFIG_HOME environment variable exists then run
-source <(curl -s https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh)
+curl -s https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh | bash
+```
+
+Or using wget
+```bash
+# Verify the $XDG_CONFIG_HOME environment variable exists then run
+wget -qcO - https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh | bash
 ```
 
 ### Install from Source

--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -16,7 +16,18 @@ echo "Verify ksops plugin directory exists and is empty"
 rm -rf $PLUGIN_PATH || true
 mkdir -p $PLUGIN_PATH
 
-ARCH=$(uname -m)
+get_machine_arch () {
+    machine_arch=""
+    case $(uname -m) in
+        i386)   machine_arch="i386" ;;
+        i686)    machine_arch="i386" ;;
+        x86_64)  machine_arch="x86_64" ;;
+        aarch64) machine_arch="arm64" ;;
+    esac
+    echo $machine_arch
+}
+
+ARCH=$(get_machine_arch)
 OS=""
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)
@@ -40,5 +51,12 @@ esac
 
 
 echo "Downloading latest release to ksops plugin path"
-wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -xz -C $PLUGIN_PATH
+if [ -x "$(command -v wget)" ]; then
+    wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -xz -C $PLUGIN_PATH
+elif [ -x "$(command -v curl)" ]; then
+    curl -s -L https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz | tar -xz -C $PLUGIN_PATH
+else
+    echo "This script requires either wget or curl."
+    exit 1
+fi
 echo "Successfully installed ksops"


### PR DESCRIPTION
    * Update README.md to reflect below changes
    * add bash function to get machine architecture
    * function matches case output options to existing release assets
    * use if,elif,else block to allow script to work with wget or curl

I noted that uname -m on arm is aarch64 but release assets are named arm64,
the added function matches the case to what is set in release assets build.

Also, the instruction in [README.md](https://github.com/techsolx/kustomize-sops#install-the-latest-release)
reference the use of curl and the script calls for wget, so I allowed
both.

I noted that the use of `source <(input)` will cause shell to
reset or close silently, if the script fails.

This silent failure will also close any tmux session, if the user is a tmux users.

I opted to pipe the output to bash as this script requires it anyway.

I note some similar type work here:
https://github.com/viaduct-ai/kustomize-sops/pull/139/

Successful test with darwin x86_64 and linux x86_64 and arm64.