### PR TITLE
bumping kustomize for newer includeTemplates label support

### DIFF
--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -6,7 +6,7 @@ KUSTOMIZE="kustomize"
 function install_kustomize() {
   echo "Installing $KUSTOMIZE..."
   KUSTOMIZE_MAJOR_VERSION='v4'
-  KUSTOMIZE_VERSION="${KUSTOMIZE_MAJOR_VERSION}.5.2"
+  KUSTOMIZE_VERSION="${KUSTOMIZE_MAJOR_VERSION}.5.7"
   BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
   KSOPS_VERSION=$(git rev-parse HEAD)
   KSOPS_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || true )


### PR DESCRIPTION
bumping kustomize for newer [includeTemplates](https://github.com/kubernetes-sigs/kustomize/blob/master/api/types/labels.go#L18) label support
