### PR TITLE
Publish Multi-Arch Manifest in Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 bin
 
 ksops
+
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,22 +16,21 @@ builds:
 
 archives:
   - id: default
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
   - id: latest
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-
-    name_template: "{{ .ProjectName }}_latest_{{ .Os }}_{{ .Arch }}"
+    name_template: >-
+      {{ .ProjectName }}_
+      latest_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,44 +66,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/amd64"
-
-    # For multiple architectures
-    use: buildx
-
-    # If your Dockerfile copies files other than the binary itself,
-    # you should list them here as well.
-    # Note that goreleaser will create the same structure inside the temporary
-    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
-    # `COPY foo/bar.json /whatever.json`.
-    # Also note that the paths here are relative to the folder in which
-    # goreleaser is being run.
-    # This field does not support wildcards, you can add an entire folder here
-    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
-    extra_files:
-      - go.mod
-      - go.sum
-      - Makefile
-      - scripts/
-      - ksops.go
-      # include .git for version
-      - .git/
-
-  # Templates of the Docker image names.
-  - image_templates:
-      - "viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
-      - "viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"
-      - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
-      - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"
-
-    # Template of the docker build flags.
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/arm64"
+      - "--platform=linux/amd64,linux/arm64"
 
     # For multiple architectures
     use: buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,14 +48,16 @@ release:
     name: kustomize-sops
 
 dockers:
+
+  - use: buildx
   # Templates of the Docker image names.
-  - image_templates:
-      - "viaductoss/{{ .ProjectName }}:latest"
-      - "viaductoss/{{ .ProjectName }}:{{ .Tag }}"
-      - "viaductoss/{{ .ProjectName }}:v{{ .Major }}"
-      - "quay.io/viaductoss/{{ .ProjectName }}:latest"
-      - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}"
-      - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}"
+    image_templates:
+      - "viaductoss/{{ .ProjectName }}:latest-amd64"
+      - "viaductoss/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "viaductoss/{{ .ProjectName }}:v{{ .Major }}-amd64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:latest-amd64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}-amd64"
 
     # Template of the docker build flags.
     build_flag_templates:
@@ -64,10 +66,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/amd64,linux/arm64"
-
-    # For multiple architectures
-    use: buildx
+      - "--platform=linux/amd64"
 
     # If your Dockerfile copies files other than the binary itself,
     # you should list them here as well.
@@ -86,3 +85,74 @@ dockers:
       - ksops.go
       # include .git for version
       - .git/
+
+  - use: buildx
+  # Templates of the Docker image names.
+    image_templates:
+      - "viaductoss/{{ .ProjectName }}:latest-arm64"
+      - "viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
+      - "viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:latest-arm64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
+      - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"
+
+    # Template of the docker build flags.
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64"
+
+
+    # If your Dockerfile copies files other than the binary itself,
+    # you should list them here as well.
+    # Note that goreleaser will create the same structure inside the temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # goreleaser is being run.
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files:
+      - go.mod
+      - go.sum
+      - Makefile
+      - scripts/
+      - ksops.go
+      # include .git for version
+      - .git/
+
+docker_manifests:
+- name_template: "viaductoss/{{ .ProjectName }}:latest"
+  image_templates:
+  - "viaductoss/{{ .ProjectName }}:latest-amd64"
+  - "viaductoss/{{ .ProjectName }}:latest-arm64"
+
+- name_template: "viaductoss/{{ .ProjectName }}:{{ .Tag }}"
+  image_templates:
+  - "viaductoss/{{ .ProjectName }}:{{ .Tag }}-amd64"
+  - "viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
+
+
+- name_template: "viaductoss/{{ .ProjectName }}:v{{ .Major }}"
+  image_templates:
+  - "viaductoss/{{ .ProjectName }}:v{{ .Major }}-amd64"
+  - "viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"
+
+- name_template: "quay.io/viaductoss/{{ .ProjectName }}:latest"
+  image_templates:
+  - "quay.io/viaductoss/{{ .ProjectName }}:latest-amd64"
+  - "quay.io/viaductoss/{{ .ProjectName }}:latest-arm64"
+
+- name_template: "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}"
+  image_templates:
+  - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}-amd64"
+  - "quay.io/viaductoss/{{ .ProjectName }}:{{ .Tag }}-arm64"
+
+
+- name_template: "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}"
+  image_templates:
+  - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}-amd64"
+  - "quay.io/viaductoss/{{ .ProjectName }}:v{{ .Major }}-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
 archives:
   - id: default
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}_{{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -25,8 +25,7 @@ archives:
 
   - id: latest
     name_template: >-
-      {{ .ProjectName }}_
-      latest_
+      {{ .ProjectName }}_latest_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
Closes https://github.com/viaduct-ai/kustomize-sops/issues/167

### Description
Follow https://goreleaser.com/customization/docker_manifest/#customization to publish multi-arch manifests 

I need to figure out the best way to re-release `v4` and `v3.10` to make this available to users.

- feat: publish multi-arch manifest docker image for releases
- chore: remove references to deprecated flag
