### PR TITLE
Add Image Source OCI Label to Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.source="https://github.com/viaduct-ai/kustomize-sops"
 ARG GO_VERSION="1.19"
 
 #--------------------------------------------#


### PR DESCRIPTION
Closes #171

### Description

Support [Renovate](https://docs.renovatebot.com/modules/datasource/docker/) by adding the necessary OCI label
