### PR TITLE
feat: support remote refs in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ FROM debian:bullseye-slim
 
 LABEL org.opencontainers.image.source="https://github.com/viaduct-ai/kustomize-sops"
 
+# ca-certs and git could be required if kustomize remote-refs are used
+RUN apt update -y \
+    && apt install -y git ca-certificates \
+    && apt clean -y && rm -rf /var/lib/apt/lists/*
+
 # Copy only necessary files from the builder stage
 COPY --from=builder /go/bin/ksops /usr/local/bin/ksops
 COPY --from=builder /go/bin/kustomize /usr/local/bin/kustomize


### PR DESCRIPTION
Some users may want to take advantage of remote references to build
resources. These could be either over HTTPS or using git which are
both supported by Kustomize.

This commit adds ca-certificates and the git package to the final
image to support either approach.
