### PR TITLE
fix: extract only ksops script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Or using wget
 wget -qcO - https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh | bash
 ```
 
+If you receive a `Permission denied` error, try running the command with `sudo`
+
+```bash
+wget -qcO - https://raw.githubusercontent.com/viaduct-ai/kustomize-sops/master/scripts/install-ksops-archive.sh | sudo bash 
+```
+
 ### Install from Source
 
 _Note:_ Installing from source requires Go

--- a/scripts/install-ksops-archive.sh
+++ b/scripts/install-ksops-archive.sh
@@ -44,11 +44,17 @@ esac
 
 echo "Downloading latest release to ksops plugin path"
 if [ -x "$(command -v wget)" ]; then
-    wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -xz -C $PLUGIN_PATH
+    wget -c https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz -O - | tar -zxvf - ksops
 elif [ -x "$(command -v curl)" ]; then
-    curl -s -L https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz | tar -xz -C $PLUGIN_PATH
+    curl -s -L https://github.com/viaduct-ai/kustomize-sops/releases/latest/download/ksops_latest_${OS}_${ARCH}.tar.gz | tar -zxvf - ksops
 else
     echo "This script requires either wget or curl."
     exit 1
 fi
-echo "Successfully installed ksops"
+
+if mv ksops $PLUGIN_PATH; then
+  echo "Successfully installed ksops"
+else
+  echo "Failed to move ksops to $PLUGIN_PATH. Maybe you should run this script as root."
+  exit 1
+fi


### PR DESCRIPTION
## Description 

This PR change extract script by extracting only `ksops` binary. 

- Extract only `ksops` script in install 
- Show error if user does not have access to `/usr/local/bin`
- Added documentation about `sudo` command as root if not have permission.


Closes #195