### PR TITLE
Support for binary encrypted files

### DIFF
--- a/test/krm/envs/want.yaml
+++ b/test/krm/envs/want.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
+data:
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  password: 1f2d1e2e67df
-  username: admin

--- a/test/krm/file/want.yaml
+++ b/test/krm/file/want.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
+data:
+  secret.enc.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  secret.enc.yaml: |
-    username: admin
-    password: 1f2d1e2e67df
 type: Opaque

--- a/test/krm/metadata/want.yaml
+++ b/test/krm/metadata/want.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+data:
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 kind: Secret
 metadata:
   annotations:
@@ -7,6 +10,3 @@ metadata:
     foo: bar
   name: mysecret
   namespace: test
-stringData:
-  password: 1f2d1e2e67df
-  username: admin

--- a/test/krm/override/want.yaml
+++ b/test/krm/override/want.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
+data:
+  secret.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  secret.yaml: |
-    username: admin
-    password: 1f2d1e2e67df
 type: Opaque

--- a/test/legacy/envs/want.yaml
+++ b/test/legacy/envs/want.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
+data:
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  password: 1f2d1e2e67df
-  username: admin

--- a/test/legacy/file/want.yaml
+++ b/test/legacy/file/want.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
+data:
+  secret.enc.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  secret.enc.yaml: |
-    username: admin
-    password: 1f2d1e2e67df
 type: Opaque

--- a/test/legacy/metadata/want.yaml
+++ b/test/legacy/metadata/want.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+data:
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 kind: Secret
 metadata:
   annotations:
@@ -7,6 +10,3 @@ metadata:
     foo: bar
   name: mysecret
   namespace: test
-stringData:
-  password: 1f2d1e2e67df
-  username: admin

--- a/test/legacy/override/want.yaml
+++ b/test/legacy/override/want.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
+data:
+  secret.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
 kind: Secret
 metadata:
   name: mysecret
-stringData:
-  secret.yaml: |
-    username: admin
-    password: 1f2d1e2e67df
 type: Opaque


### PR DESCRIPTION
I ran into the issue that I cannot encrypt a binary file and import that as file secret. With this patch it is possible.

Generated secrets use data instead of stringdata.

Using the base64 encoded data attributes allow the use of encrypted binary files to be used.