### PR TITLE
feat: added binaryFiles option

### DIFF
--- a/README-legacy.md
+++ b/README-legacy.md
@@ -189,7 +189,28 @@ https://github.com/viaduct-ai/kustomize-sops/issues
 `KSOPS` can also generate a Kubernetes Secret directly from encrypted files or dotenv files.
 
 ```bash
-# Create a Kubernetes Secret from encrypted file
+# Create a Kubernetes Secret from encrypted binary file
+cat <<EOF > secret-generator.yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: example-secret-generator
+secretFrom:
+- metadata:
+    name: secret-name
+    labels:
+      app: foo
+    annotations:
+      kustomize.config.k8s.io/needs-hash: "false"
+  type: Opaque
+  binaryFiles:
+  - ./secret.enc
+  - secret=./secret.enc
+EOF
+```
+
+```bash
+# Create a Kubernetes Secret from encrypted text-based file
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1
 kind: ksops

--- a/README-legacy.md
+++ b/README-legacy.md
@@ -189,7 +189,7 @@ https://github.com/viaduct-ai/kustomize-sops/issues
 `KSOPS` can also generate a Kubernetes Secret directly from encrypted files or dotenv files.
 
 ```bash
-# Create a Kubernetes Secret from encrypted text-based file
+# Create a Kubernetes Secret from encrypted file
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1
 kind: ksops

--- a/README-legacy.md
+++ b/README-legacy.md
@@ -189,27 +189,6 @@ https://github.com/viaduct-ai/kustomize-sops/issues
 `KSOPS` can also generate a Kubernetes Secret directly from encrypted files or dotenv files.
 
 ```bash
-# Create a Kubernetes Secret from encrypted binary file
-cat <<EOF > secret-generator.yaml
-apiVersion: viaduct.ai/v1
-kind: ksops
-metadata:
-  name: example-secret-generator
-secretFrom:
-- metadata:
-    name: secret-name
-    labels:
-      app: foo
-    annotations:
-      kustomize.config.k8s.io/needs-hash: "false"
-  type: Opaque
-  binaryFiles:
-  - ./secret.enc
-  - secret=./secret.enc
-EOF
-```
-
-```bash
 # Create a Kubernetes Secret from encrypted text-based file
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1

--- a/README.md
+++ b/README.md
@@ -200,7 +200,32 @@ https://github.com/viaduct-ai/kustomize-sops/issues
 `KSOPS` can also generate a Kubernetes Secret directly from encrypted files or dotenv files.
 
 ```bash
-# Create a Kubernetes Secret from encrypted file
+# Create a Kubernetes Secret from encrypted binary file
+cat <<EOF > secret-generator.yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: example-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+        exec:
+          path: ksops
+secretFrom:
+- metadata:
+    name: secret-name
+    labels:
+      app: foo
+    annotations:
+      kustomize.config.k8s.io/needs-hash: "false"
+  type: Opaque
+  binaryFiles:
+  - ./secret.enc
+  - secret=./secret.enc
+EOF
+```
+
+```bash
+# Create a Kubernetes Secret from encrypted text-based file
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1
 kind: ksops

--- a/README.md
+++ b/README.md
@@ -199,33 +199,9 @@ https://github.com/viaduct-ai/kustomize-sops/issues
 
 `KSOPS` can also generate a Kubernetes Secret directly from encrypted files or dotenv files.
 
-```bash
-# Create a Kubernetes Secret from encrypted binary file
-cat <<EOF > secret-generator.yaml
-apiVersion: viaduct.ai/v1
-kind: ksops
-metadata:
-  name: example-secret-generator
-  annotations:
-    config.kubernetes.io/function: |
-        exec:
-          path: ksops
-secretFrom:
-- metadata:
-    name: secret-name
-    labels:
-      app: foo
-    annotations:
-      kustomize.config.k8s.io/needs-hash: "false"
-  type: Opaque
-  binaryFiles:
-  - ./secret.enc
-  - secret=./secret.enc
-EOF
-```
+#### Create a Kubernetes Secret from encrypted text-based file
 
 ```bash
-# Create a Kubernetes Secret from encrypted text-based file
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1
 kind: ksops
@@ -249,8 +225,35 @@ secretFrom:
 EOF
 ```
 
+#### Create a Kubernetes Secret from encrypted binary file
+
 ```bash
-# Create a Kubernetes Secret from encrypted dotenv file
+cat <<EOF > secret-generator.yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: example-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+        exec:
+          path: ksops
+secretFrom:
+- metadata:
+    name: secret-name
+    labels:
+      app: foo
+    annotations:
+      kustomize.config.k8s.io/needs-hash: "false"
+  type: Opaque
+  binaryFiles:
+  - ./secret.enc
+  - secret=./secret.enc
+EOF
+```
+
+#### Create a Kubernetes Secret from an encrypted dotenv file
+
+```bash
 cat <<EOF > secret-generator.yaml
 apiVersion: viaduct.ai/v1
 kind: ksops

--- a/ksops_test.go
+++ b/ksops_test.go
@@ -64,6 +64,10 @@ func TestKSOPSPluginInstallation(t *testing.T) {
 			dir:  "test/legacy/file",
 		},
 		{
+			name: "Legacy From Binary File",
+			dir:  "test/legacy/binaryfile",
+		},
+		{
 			name: "Legacy From Envs",
 			dir:  "test/legacy/envs",
 		},

--- a/ksops_test.go
+++ b/ksops_test.go
@@ -96,6 +96,10 @@ func TestKSOPSPluginInstallation(t *testing.T) {
 			dir:  "test/krm/file",
 		},
 		{
+			name: "KRM From Binary File",
+			dir:  "test/krm/binaryfile",
+		},
+		{
 			name: "KRM From Envs",
 			dir:  "test/krm/envs",
 		},

--- a/test/krm/binaryfile/generate-resources.yaml
+++ b/test/krm/binaryfile/generate-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-from-generator
+  annotations:
+    config.kubernetes.io/function: |
+        exec:
+          # if the binary is your PATH, you can do 
+          path: ksops
+          # otherwise, path should be relative to manifest files, like
+          # path: ../../../ksops
+secretFrom:
+- metadata:
+    name: mysecret
+  type: Opaque
+  binaryFiles:
+  - ./secret.enc.yaml

--- a/test/krm/binaryfile/kustomization.yaml
+++ b/test/krm/binaryfile/kustomization.yaml
@@ -1,0 +1,2 @@
+generators:
+  - ./generate-resources.yaml

--- a/test/krm/binaryfile/secret.enc.yaml
+++ b/test/krm/binaryfile/secret.enc.yaml
@@ -1,0 +1,28 @@
+username: ENC[AES256_GCM,data:wm8jYTk=,iv:uODPx9IQmb2gQi2oZ6gpmIGddMN7n2ogKdweMjIZIHw=,tag:xnfYKwnirnOV3tV7CFvlvA==,type:str]
+password: ENC[AES256_GCM,data:Lpu0v6Qjt6wLmYZv,iv:P7kfBIuJ7M86Oh43q9FpUDgUCK4REColGTTFGFdhjD0=,tag:wSNv3kOLhdNxBK0r3MNLpw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-12-14T18:15:56Z"
+    mac: ENC[AES256_GCM,data:mJUZQ0L26QeAkip3WnGxE/p3JAfgLbF5F2MXElcQRLvKberT0cF6MiOXXXCXFyc1/G/HMYVFGMevEuqFEMwAzZCp4oa70KclZTnE3r8/7lmtvNsF+YbLvRRy5Ib5pwpVYBSFp3RNeRHXmw+lUjz2q61DBK40tyHbRrbXvq0ITy4=,iv:shT/5S+8sjj3gdVSYTNX1r0y0db3rNiQ3YIjIP/0BUM=,tag:VPXX7gTNpsnQDe2U++hexA==,type:str]
+    pgp:
+        - created_at: "2022-12-14T18:15:50Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMAyUpShfNkFB/AQf/eWYqsnyMtmf1DpllbYFgViTaxTfZNbS+qF9BJeGoL/Q4
+            etjpXqqkl61RBzuLxj7KlM00fFpXCwTLnhaUzGIPaAvojHhk3xIT3lBBci3tshlP
+            qZ8PVzKIhVfBT8zoZ5hhR5mH7iT0SwZaD6RLepe1ygwXcS33WSf7srvuIydeAaTE
+            nxOcszcw+1/gZ88rcqmNQ8EnD4gZeswOLQiLOCliHAmZBaW3yybwp3GWbbqiJLYl
+            RsKCOkIfX0gQVI+BXb8wB1FukXl3ZiefO0zDoTZzV/hP8tq2MEhYyMMb/w/5qJo5
+            O49kCAo0nItiTFzMI1jKH3GdO9HSdAEvm4RZPGQSEdJeAWyJxw8Hy9HaecQchwCh
+            PU5nil4v656adnP+gAcmnUvjvq3WQESNkSYqGttXsxCN+0REP0mR2OuaK1LQJkY4
+            zr6Ky43znNJ33mgVYF1NKKJN00Ip8GF4l/Km24FnvQ==
+            =4non
+            -----END PGP MESSAGE-----
+          fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.7.2

--- a/test/krm/binaryfile/want.yaml
+++ b/test/krm/binaryfile/want.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  secret.enc.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque

--- a/test/legacy/binaryfile/generate-resources.yaml
+++ b/test/legacy/binaryfile/generate-resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-from-generator
+secretFrom:
+- metadata:
+    name: mysecret
+  type: Opaque
+  binaryFiles:
+  - ./secret.enc.yaml

--- a/test/legacy/binaryfile/kustomization.yaml
+++ b/test/legacy/binaryfile/kustomization.yaml
@@ -1,0 +1,2 @@
+generators:
+  - ./generate-resources.yaml

--- a/test/legacy/binaryfile/secret.enc.yaml
+++ b/test/legacy/binaryfile/secret.enc.yaml
@@ -1,0 +1,28 @@
+username: ENC[AES256_GCM,data:wm8jYTk=,iv:uODPx9IQmb2gQi2oZ6gpmIGddMN7n2ogKdweMjIZIHw=,tag:xnfYKwnirnOV3tV7CFvlvA==,type:str]
+password: ENC[AES256_GCM,data:Lpu0v6Qjt6wLmYZv,iv:P7kfBIuJ7M86Oh43q9FpUDgUCK4REColGTTFGFdhjD0=,tag:wSNv3kOLhdNxBK0r3MNLpw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-12-14T18:15:56Z"
+    mac: ENC[AES256_GCM,data:mJUZQ0L26QeAkip3WnGxE/p3JAfgLbF5F2MXElcQRLvKberT0cF6MiOXXXCXFyc1/G/HMYVFGMevEuqFEMwAzZCp4oa70KclZTnE3r8/7lmtvNsF+YbLvRRy5Ib5pwpVYBSFp3RNeRHXmw+lUjz2q61DBK40tyHbRrbXvq0ITy4=,iv:shT/5S+8sjj3gdVSYTNX1r0y0db3rNiQ3YIjIP/0BUM=,tag:VPXX7gTNpsnQDe2U++hexA==,type:str]
+    pgp:
+        - created_at: "2022-12-14T18:15:50Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMAyUpShfNkFB/AQf/eWYqsnyMtmf1DpllbYFgViTaxTfZNbS+qF9BJeGoL/Q4
+            etjpXqqkl61RBzuLxj7KlM00fFpXCwTLnhaUzGIPaAvojHhk3xIT3lBBci3tshlP
+            qZ8PVzKIhVfBT8zoZ5hhR5mH7iT0SwZaD6RLepe1ygwXcS33WSf7srvuIydeAaTE
+            nxOcszcw+1/gZ88rcqmNQ8EnD4gZeswOLQiLOCliHAmZBaW3yybwp3GWbbqiJLYl
+            RsKCOkIfX0gQVI+BXb8wB1FukXl3ZiefO0zDoTZzV/hP8tq2MEhYyMMb/w/5qJo5
+            O49kCAo0nItiTFzMI1jKH3GdO9HSdAEvm4RZPGQSEdJeAWyJxw8Hy9HaecQchwCh
+            PU5nil4v656adnP+gAcmnUvjvq3WQESNkSYqGttXsxCN+0REP0mR2OuaK1LQJkY4
+            zr6Ky43znNJ33mgVYF1NKKJN00Ip8GF4l/Km24FnvQ==
+            =4non
+            -----END PGP MESSAGE-----
+          fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.7.2

--- a/test/legacy/binaryfile/want.yaml
+++ b/test/legacy/binaryfile/want.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  secret.enc.yaml: dXNlcm5hbWU6IGFkbWluCnBhc3N3b3JkOiAxZjJkMWUyZTY3ZGYK
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque


### PR DESCRIPTION
I ran into the issue that I cannot encrypt a binary file and import that as file secret. With this patch it is possible.

Generated secrets use data instead of stringdata.

Using the base64 encoded data attributes allow the use of encrypted binary files to be used.

This is a followup PR to https://github.com/viaduct-ai/kustomize-sops/pull/210