### PR TITLE
fear: Generate secrets from templating

### DIFF
--- a/ksops.go
+++ b/ksops.go
@@ -12,16 +12,16 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
 	"github.com/joho/godotenv"
+	"os"
+	"path/filepath"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
+	"strings"
+	"text/template"
 )
 
 type kubernetesSecret struct {
@@ -41,9 +41,28 @@ type secretFrom struct {
 	Type        string           `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
+type templateDef struct {
+	Metadata   types.ObjectMeta  `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Type       string            `json:"type,omitempty" yaml:"type,omitempty"`
+	StringData map[string]string `json:"stringData,omitempty" yaml:"stringData,omitempty"`
+	Data       map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	Files      []string          `json:"files,omitempty" yaml:"files,omitempty"`
+}
+
+type templateVars struct {
+	Files []string `json:"files,omitempty" yaml:"files,omitempty"`
+	Envs  []string `json:"envs,omitempty" yaml:"envs,omitempty"`
+}
+
+type secretFromTemplate struct {
+	Template templateDef  `json:"template,omitempty" yaml:"template,omitempty"`
+	Vars     templateVars `json:"vars,omitempty" yaml:"vars,omitempty"`
+}
+
 type ksops struct {
-	Files      []string     `json:"files,omitempty" yaml:"files,omitempty"`
-	SecretFrom []secretFrom `json:"secretFrom,omitempty" yaml:"secretFrom,omitempty"`
+	Files              []string             `json:"files,omitempty" yaml:"files,omitempty"`
+	SecretFrom         []secretFrom         `json:"secretFrom,omitempty" yaml:"secretFrom,omitempty"`
+	SecretFromTemplate []secretFromTemplate `json:"secretFromTemplate,omitempty" yaml:"secretFromTemplate,omitempty"`
 }
 
 func help() {
@@ -138,8 +157,8 @@ func generate(raw []byte) (string, error) {
 		return "", fmt.Errorf("error unmarshalling manifest content: %q \n%s", err, raw)
 	}
 
-	if manifest.Files == nil && manifest.SecretFrom == nil {
-		return "", fmt.Errorf("missing the required 'files' or 'secretFrom' key in the ksops manifests: %s", raw)
+	if manifest.Files == nil && manifest.SecretFrom == nil && manifest.SecretFromTemplate == nil {
+		return "", fmt.Errorf("missing the required 'files', 'secretFrom', or 'secretFromTemplate' key in the ksops manifests: %s", raw)
 	}
 
 	var documents [][]byte
@@ -207,6 +226,78 @@ func generate(raw []byte) (string, error) {
 		documents = append(documents, d)
 	}
 
+	for _, secretFrom := range manifest.SecretFromTemplate {
+		// Read template
+		if secretFrom.Template.StringData == nil {
+			secretFrom.Template.StringData = make(map[string]string)
+		}
+		for _, file := range secretFrom.Template.Files {
+			key, path := fileKeyPath(file)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return "", fmt.Errorf("error reading file %q from secretFrom.template.files: %w", path, err)
+			}
+			secretFrom.Template.StringData[key] = string(data)
+		}
+
+		// Read variables
+		vars := make(map[string]string)
+		for _, file := range secretFrom.Vars.Files {
+			key, path := fileKeyPath(file)
+			data, err := decryptFile(path)
+			if err != nil {
+				return "", fmt.Errorf("error decrypting file %q from secretFromTemplate.vars.files: %w", path, err)
+			}
+
+			vars[key] = string(data)
+		}
+		for _, file := range secretFrom.Vars.Envs {
+			data, err := decryptFile(file)
+			if err != nil {
+				return "", fmt.Errorf("error decrypting file %q from secretFromTemplate.vars.envs: %w", file, err)
+			}
+
+			env, err := godotenv.Unmarshal(string(data))
+			if err != nil {
+				return "", fmt.Errorf("error unmarshalling .env file %q: %w", file, err)
+			}
+			for k, v := range env {
+				vars[k] = v
+			}
+		}
+
+		// Template stringData and data fields
+		stringData := make(map[string]string, len(secretFrom.Template.StringData))
+		binaryData := make(map[string]string, len(secretFrom.Template.Data))
+		for k, v := range secretFrom.Template.StringData {
+			stringData[k], err = execTemplate(v, vars)
+			if err != nil {
+				return "", fmt.Errorf("error templating from secretFromTemplate.template.stringData.%v: %w", k, err)
+			}
+		}
+		for k, v := range secretFrom.Template.Data {
+			binaryData[k], err = execTemplate(v, vars)
+			if err != nil {
+				return "", fmt.Errorf("error executing template from secretFrom.template.data.%v: %w", k, err)
+			}
+		}
+
+		// Construct secret document
+		s := kubernetesSecret{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Metadata:   secretFrom.Template.Metadata,
+			Type:       secretFrom.Template.Type,
+			StringData: stringData,
+			Data:       binaryData,
+		}
+		d, err := yaml.Marshal(&s)
+		if err != nil {
+			return "", fmt.Errorf("error marshalling manifest: %w", err)
+		}
+		documents = append(documents, d)
+	}
+
 	var output bytes.Buffer
 	for i, doc := range documents {
 		output.Write(doc)
@@ -217,6 +308,19 @@ func generate(raw []byte) (string, error) {
 	}
 
 	return output.String(), nil
+}
+
+func execTemplate(tmpl string, vars map[string]string) (string, error) {
+	t, err := template.New("tmpl").Parse(tmpl)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template: %w", err)
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, vars)
+	if err != nil {
+		return "", fmt.Errorf("error executing template: %w", err)
+	}
+	return buf.String(), nil
 }
 
 func decryptFile(file string) ([]byte, error) {

--- a/ksops_test.go
+++ b/ksops_test.go
@@ -115,6 +115,14 @@ func TestKSOPSPluginInstallation(t *testing.T) {
 			name: "KRM Secret Metadata",
 			dir:  "test/krm/metadata",
 		},
+		{
+			name: "KRM Secret from Template",
+			dir:  "test/krm/template",
+		},
+		{
+			name: "KRM Secret from Template using File",
+			dir:  "test/krm/template-file",
+		},
 	}
 
 	// run kustomize version to validate installation

--- a/test/krm/template-file/config-template.yaml
+++ b/test/krm/template-file/config-template.yaml
@@ -1,0 +1,4 @@
+cleartext_field: "foo"
+user: "{{ .username }}"
+pass: "{{ .password }}"
+role: "{{ .role }}"

--- a/test/krm/template-file/generate-resources.yaml
+++ b/test/krm/template-file/generate-resources.yaml
@@ -1,0 +1,23 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-from-generator
+  annotations:
+    config.kubernetes.io/function: |
+        exec:
+          # if the binary is your PATH, you can do 
+          path: ksops
+          # otherwise, path should be relative to manifest files, like
+          # path: ../../../ksops
+secretFromTemplate:
+- template:
+    metadata:
+      name: mysecret
+    type: Opaque
+    files:
+    - config.yaml=./config-template.yaml
+  vars:
+    files:
+    - role=./secret.enc.txt
+    envs:
+    - ./secret.enc.env

--- a/test/krm/template-file/kustomization.yaml
+++ b/test/krm/template-file/kustomization.yaml
@@ -1,0 +1,2 @@
+generators:
+  - ./generate-resources.yaml

--- a/test/krm/template-file/secret.enc.env
+++ b/test/krm/template-file/secret.enc.env
@@ -1,0 +1,9 @@
+password=ENC[AES256_GCM,data:POoodkvLJlYkuFwZ,iv:zAqcWK57VQr59EkJ3Bx6utY1wexj1+zDZasl76fzMho=,tag:1z4RJr+7BTeYMs3P7WFKGw==,type:str]
+username=ENC[AES256_GCM,data:Cpxi7uQ=,iv:qEmlgTHiOsEF83VR7sranL4uuvS/EsF9Udlt9ykcGd0=,tag:80Rg/s0jsvefbSwjgIcUTQ==,type:str]
+sops_version=3.7.2
+sops_lastmodified=2022-12-14T18:15:04Z
+sops_unencrypted_regex=^(apiVersion|metadata|kind|type)$
+sops_mac=ENC[AES256_GCM,data:KHJWDwHp9AjlQhXmOOIIOs3zsiIA4UkE5O9ue81qffkUIEvG0ts8RqSI0JetdxvqFN8jMAwgxKZlslsViMxTU9dD9h3WCXCteh6wcBxSSNLbuAnxAlZke2tR10ZCWizGA3oBcTcd/maN+hZq5fNqBMzdUpqyhmJZ9/OV9w6CNiU=,iv:wpUpAzsyEcUByWU9Km2gfiTyCE3RQjvkbW5EV/7OZ80=,tag:I4PMdJiPJ63l0KDmWFZmwg==,type:str]
+sops_pgp__list_0__map_enc=-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQgAkk0vfCLQKkP8tDXe5Bmu4s1bndkH5YyyNlUgOTDeCzDx\nkYGv8lXwCpGBlc2RQxzB4Ygr8k80M76IGZHDWrDLuNkNuKriPZQPP4OIpbOSGnHs\nQmLvJpICisZjUbo6gQpHi5iRZ3GiGFyX386bASDJbDM6FKft6MBarXApt1LYfL9z\no83MK4ZYVR0Nh4ttUXwDbug2de9hIGmnnXCWOQ7XLAlK+TT6/qdocAksTb+7Te1l\n8lQz/Slq1vyctOChZG/m2Vc6w6Ux0c01BOUB7uCcMnygndbHkgbsMBw6pru3Dv8V\n+Kpb40+3rY+u1dXediYV62vX48SUv6XPChUlAK2k1NJeAdd0s0ukU6thdloWjKZa\n7KH2RGDS7D7khRP5dyIQYf1DiLEUNfG/+J6zgU7DJep05mOvoapRp/vBHGTssjtj\nHjjSa4/kV89Brm6mPRbCnOj4HHWrP/0lKfecmEsBPg==\n=h8SP\n-----END PGP MESSAGE-----\n
+sops_pgp__list_0__map_fp=FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+sops_pgp__list_0__map_created_at=2022-12-14T18:14:54Z

--- a/test/krm/template-file/secret.enc.txt
+++ b/test/krm/template-file/secret.enc.txt
@@ -1,0 +1,21 @@
+{
+	"data": "ENC[AES256_GCM,data:KFazMWP2kQ==,iv:NW0McgCBG0SyUFrhbOJMA2JuEZMNjnvhebc4rG99Fwc=,tag:jCMY9g28qXgxgtlBS2/MiQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-10-20T05:30:27Z",
+		"mac": "ENC[AES256_GCM,data:ot7nHiAZQ4m9t6UXo7xVjDYQaXOtnwG7DVpdyevP5GijOyVhJlE4+DBMzgSI19CEXkZZk5v6KvRdjO0LcyAfVLaf/9+jadc5EB9CNwZ8mjs0gahXzW00VOKbxiWMjmVfJuKjJKqvTk+N/C6Ps0wqtDW5NsS+MLym5Zd2vHw3aU4=,iv:w3ctBqJvwSnLZkl6K3MrdfGSh/pRz/gT6MlgT+j6ljo=,tag:r1oUCDA9fFraMoBK270niA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2024-10-20T05:30:26Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQgAgLTzmwsYMyrKZjZAx/g3XiMMAbbz5oAg5M6ovUVc/0jA\nckXInXVz683Ej0437DINxeOyT455MuRqTrJfUd1BdZErnu2O/5ApimUl14XMP9K8\nEmNd9+C2lbH2UmGuMezsGNTtdurMjYTzuTPBnufuc2J53eE9xs/xZ0StAuLig+X0\na2q/aul0iTkasr0VX5wrmYEsaHQD+VZvurSoGaCjv4qq3IGMitT5PtijCKLYroEX\nptYMMgchJTy+hI75snMrMhfnucHCjJtnDEJweGAV9CXxbtDuJq1r4zIAsNMODJ9H\nw975TMu3xBJN3vXNUPUe4zBxsX5GlCaqqHBqF5awKdJeAYwC7RCe1gMw5jmYvyqW\nvnooICVWf7gu6IVYSSEY007jsRolM+QfdZ8mWu5YKRtAjMwLP8RGSRggB++YrBMp\nPpE3RWpvIN06OIoEfUFukd0wwNjcRWynWKtQhlEFVA==\n=drlB\n-----END PGP MESSAGE-----\n",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_regex": "^(apiVersion|metadata|kind|type)$",
+		"version": "3.7.3"
+	}
+}

--- a/test/krm/template-file/want.yaml
+++ b/test/krm/template-file/want.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+stringData:
+  config.yaml: |
+    cleartext_field: "foo"
+    user: "admin"
+    pass: "1f2d1e2e67df"
+    role: "foo-bar"
+type: Opaque

--- a/test/krm/template/generate-resources.yaml
+++ b/test/krm/template/generate-resources.yaml
@@ -1,0 +1,27 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-from-generator
+  annotations:
+    config.kubernetes.io/function: |
+        exec:
+          # if the binary is your PATH, you can do 
+          path: ksops
+          # otherwise, path should be relative to manifest files, like
+          # path: ../../../ksops
+secretFromTemplate:
+- template:
+    metadata:
+      name: mysecret
+    type: Opaque
+    stringData:
+      config.yaml: |
+        cleartext_field: "foo"
+        user: "{{ .username }}"
+        pass: "{{ .password }}"
+        role: "{{ .role }}"
+  vars:
+    files:
+    - role=./secret.enc.txt
+    envs:
+    - ./secret.enc.env

--- a/test/krm/template/kustomization.yaml
+++ b/test/krm/template/kustomization.yaml
@@ -1,0 +1,2 @@
+generators:
+  - ./generate-resources.yaml

--- a/test/krm/template/secret.enc.env
+++ b/test/krm/template/secret.enc.env
@@ -1,0 +1,9 @@
+password=ENC[AES256_GCM,data:POoodkvLJlYkuFwZ,iv:zAqcWK57VQr59EkJ3Bx6utY1wexj1+zDZasl76fzMho=,tag:1z4RJr+7BTeYMs3P7WFKGw==,type:str]
+username=ENC[AES256_GCM,data:Cpxi7uQ=,iv:qEmlgTHiOsEF83VR7sranL4uuvS/EsF9Udlt9ykcGd0=,tag:80Rg/s0jsvefbSwjgIcUTQ==,type:str]
+sops_version=3.7.2
+sops_lastmodified=2022-12-14T18:15:04Z
+sops_unencrypted_regex=^(apiVersion|metadata|kind|type)$
+sops_mac=ENC[AES256_GCM,data:KHJWDwHp9AjlQhXmOOIIOs3zsiIA4UkE5O9ue81qffkUIEvG0ts8RqSI0JetdxvqFN8jMAwgxKZlslsViMxTU9dD9h3WCXCteh6wcBxSSNLbuAnxAlZke2tR10ZCWizGA3oBcTcd/maN+hZq5fNqBMzdUpqyhmJZ9/OV9w6CNiU=,iv:wpUpAzsyEcUByWU9Km2gfiTyCE3RQjvkbW5EV/7OZ80=,tag:I4PMdJiPJ63l0KDmWFZmwg==,type:str]
+sops_pgp__list_0__map_enc=-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQgAkk0vfCLQKkP8tDXe5Bmu4s1bndkH5YyyNlUgOTDeCzDx\nkYGv8lXwCpGBlc2RQxzB4Ygr8k80M76IGZHDWrDLuNkNuKriPZQPP4OIpbOSGnHs\nQmLvJpICisZjUbo6gQpHi5iRZ3GiGFyX386bASDJbDM6FKft6MBarXApt1LYfL9z\no83MK4ZYVR0Nh4ttUXwDbug2de9hIGmnnXCWOQ7XLAlK+TT6/qdocAksTb+7Te1l\n8lQz/Slq1vyctOChZG/m2Vc6w6Ux0c01BOUB7uCcMnygndbHkgbsMBw6pru3Dv8V\n+Kpb40+3rY+u1dXediYV62vX48SUv6XPChUlAK2k1NJeAdd0s0ukU6thdloWjKZa\n7KH2RGDS7D7khRP5dyIQYf1DiLEUNfG/+J6zgU7DJep05mOvoapRp/vBHGTssjtj\nHjjSa4/kV89Brm6mPRbCnOj4HHWrP/0lKfecmEsBPg==\n=h8SP\n-----END PGP MESSAGE-----\n
+sops_pgp__list_0__map_fp=FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+sops_pgp__list_0__map_created_at=2022-12-14T18:14:54Z

--- a/test/krm/template/secret.enc.txt
+++ b/test/krm/template/secret.enc.txt
@@ -1,0 +1,21 @@
+{
+	"data": "ENC[AES256_GCM,data:KFazMWP2kQ==,iv:NW0McgCBG0SyUFrhbOJMA2JuEZMNjnvhebc4rG99Fwc=,tag:jCMY9g28qXgxgtlBS2/MiQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-10-20T05:30:27Z",
+		"mac": "ENC[AES256_GCM,data:ot7nHiAZQ4m9t6UXo7xVjDYQaXOtnwG7DVpdyevP5GijOyVhJlE4+DBMzgSI19CEXkZZk5v6KvRdjO0LcyAfVLaf/9+jadc5EB9CNwZ8mjs0gahXzW00VOKbxiWMjmVfJuKjJKqvTk+N/C6Ps0wqtDW5NsS+MLym5Zd2vHw3aU4=,iv:w3ctBqJvwSnLZkl6K3MrdfGSh/pRz/gT6MlgT+j6ljo=,tag:r1oUCDA9fFraMoBK270niA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2024-10-20T05:30:26Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQgAgLTzmwsYMyrKZjZAx/g3XiMMAbbz5oAg5M6ovUVc/0jA\nckXInXVz683Ej0437DINxeOyT455MuRqTrJfUd1BdZErnu2O/5ApimUl14XMP9K8\nEmNd9+C2lbH2UmGuMezsGNTtdurMjYTzuTPBnufuc2J53eE9xs/xZ0StAuLig+X0\na2q/aul0iTkasr0VX5wrmYEsaHQD+VZvurSoGaCjv4qq3IGMitT5PtijCKLYroEX\nptYMMgchJTy+hI75snMrMhfnucHCjJtnDEJweGAV9CXxbtDuJq1r4zIAsNMODJ9H\nw975TMu3xBJN3vXNUPUe4zBxsX5GlCaqqHBqF5awKdJeAYwC7RCe1gMw5jmYvyqW\nvnooICVWf7gu6IVYSSEY007jsRolM+QfdZ8mWu5YKRtAjMwLP8RGSRggB++YrBMp\nPpE3RWpvIN06OIoEfUFukd0wwNjcRWynWKtQhlEFVA==\n=drlB\n-----END PGP MESSAGE-----\n",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_regex": "^(apiVersion|metadata|kind|type)$",
+		"version": "3.7.3"
+	}
+}

--- a/test/krm/template/want.yaml
+++ b/test/krm/template/want.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+stringData:
+  config.yaml: |
+    cleartext_field: "foo"
+    user: "admin"
+    pass: "1f2d1e2e67df"
+    role: "foo-bar"
+type: Opaque


### PR DESCRIPTION
Hello ksops team!

This is a (non-breaking) feature pull request to add one advanced feature to the ksops plugin.

I have added usage and usecases to README.md, but in short, this feature allows you to use [golang text/template](https://pkg.go.dev/text/template) to template a secret from variables read via sops.
Please feel free to correct by English in README if anything feels unnatural, because I am not a native English speaker.

My usecases includes: templating a [Gitea app.ini](https://docs.gitea.com/administration/config-cheat-sheet) config file.
The app.ini is large and has quite a few fields, and a number of secret fields I would like to mask in a git repository.
(Since `.ini` is supported by sops, I guess technically I could use `unencrypted_regex` to filter out fields in `.sops.yaml`, but that would get the config file too cluttered. I would personally rather use this templating feature implemented in this PR.)

I have uploaded a built docker image to ghcr.io/motoki317/ksops of this PR so I can try it out in my environment.
You can view my refactor commits using this feature from the following links:
https://github.com/motoki317/manifest/commit/533de9f596da7154c33c1b7f56773b73669b23c6
https://github.com/motoki317/manifest/commit/570a8f39967a2a3253b0bc4814ef338e3e9f54df

I should also note that this was partially inspired by external-secret's advanced templating feature.
https://external-secrets.io/latest/guides/templating/

Thank you in advance!