### PR TITLE
chore: bump to go 1.23.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,17 +14,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.21]
-    name: ${{ matrix.os }} @ Go ${{ matrix.go }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set up Go ${{ matrix.go }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
 
       - name: Set GOPATH and PATH
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: go.mod
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/viaduct-ai/kustomize-sops
 
-go 1.22
-toolchain go1.22.9
+go 1.23.4
 
 require (
 	github.com/getsops/sops/v3 v3.9.2


### PR DESCRIPTION
- bump to use go 1.23.4
- also refine the github action workflow file a bit