### PR TITLE
fix(dockerfile): bump golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION="1.21"
+ARG GO_VERSION="1.22"
 
 #--------------------------------------------#
 #--------Build KSOPS and Kustomize-----------#


### PR DESCRIPTION
This should fix the latest attempt at pushing version 4.3.3.

Failed release: https://github.com/viaduct-ai/kustomize-sops/actions/runs/12486208111/job/34846014184