### PR TITLE
fix: add `ksops install` subcommand for distroless compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,16 +388,11 @@ spec:
       volumes:
         - name: custom-tools
           emptyDir: {}
-      # 2. Use an init container to download/copy custom binaries into the emptyDir
+      # 2. Use an init container to copy custom binaries into the emptyDir
       initContainers:
         - name: install-ksops
           image: viaductoss/ksops:v4.4.0
-          command: ["/bin/sh", "-c"]
-          args:
-            - echo "Installing KSOPS...";
-              mv ksops /custom-tools/;
-              mv kustomize /custom-tools/;
-              echo "Done.";
+          command: ["/usr/local/bin/ksops", "install", "/custom-tools"]
           volumeMounts:
             - mountPath: /custom-tools
               name: custom-tools
@@ -453,12 +448,10 @@ cat age.agekey | oc create secret generic sops-age --namespace=openshift-operato
     - name: SOPS_AGE_KEY_FILE
       value: /.config/sops/age/keys.txt
     initContainers:
-    - args:
-      - echo "Installing KSOPS..."; mv ksops /custom-tools/; mv kustomize /custom-tools/;
-        echo "Done.";
-      command:
-      - /bin/sh
-      - -c
+    - command:
+      - /usr/local/bin/ksops
+      - install
+      - /custom-tools
       image: viaductoss/ksops:v4.4.0
       name: install-ksops
       volumeMounts:
@@ -572,12 +565,7 @@ repoServer:
   initContainers:
     - name: install-ksops
       image: viaductoss/ksops:v4.4.0
-      command: ["/bin/sh", "-c"]
-      args:
-        - echo "Installing KSOPS...";
-          mv ksops /custom-tools/;
-          mv kustomize /custom-tools/;
-          echo "Done.";
+      command: ["/usr/local/bin/ksops", "install", "/custom-tools"]
       volumeMounts:
         - mountPath: /custom-tools
           name: custom-tools

--- a/install_test.go
+++ b/install_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 viaduct.ai
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a source file with known content
+	srcContent := []byte("hello world")
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, srcContent, 0755); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	dst := filepath.Join(dir, "dst")
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile() returned error: %v", err)
+	}
+
+	// Verify content matches
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination file: %v", err)
+	}
+	if string(got) != string(srcContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, srcContent)
+	}
+
+	// Verify permissions are executable
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("failed to stat destination file: %v", err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Errorf("destination file is not executable: mode=%v", info.Mode())
+	}
+}
+
+func TestCopyFileSourceNotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := copyFile(filepath.Join(dir, "nonexistent"), filepath.Join(dir, "dst"))
+	if err == nil {
+		t.Error("copyFile() should return error for nonexistent source")
+	}
+}
+
+func TestCopyFileDestDirNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("data"), 0755); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	err := copyFile(src, filepath.Join(dir, "nodir", "dst"))
+	if err == nil {
+		t.Error("copyFile() should return error when destination directory doesn't exist")
+	}
+}

--- a/ksops.go
+++ b/ksops.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,14 +58,72 @@ func help() {
 		Standalone Usage :
 		- Legacy: ksops secret-generator.yaml
 		- KRM: cat secret-generator.yaml | ksops
+
+		Install Usage (copy binaries to a target directory):
+		- ksops install /custom-tools
 `
 	fmt.Fprintf(os.Stderr, "%s", strings.ReplaceAll(msg, "		", ""))
 	os.Exit(1)
 }
 
+// installBinaries copies ksops and kustomize binaries to the target directory.
+// This enables use in distroless containers where no shell or cp/mv commands are available,
+// such as ArgoCD init containers.
+func installBinaries(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "install requires a destination directory\n")
+		fmt.Fprintf(os.Stderr, "usage: ksops install <dest-dir>\n")
+		os.Exit(1)
+	}
+
+	dest := args[0]
+
+	binaries := []struct {
+		src  string
+		name string
+	}{
+		{"/usr/local/bin/ksops", "ksops"},
+		{"/usr/local/bin/kustomize", "kustomize"},
+	}
+
+	for _, bin := range binaries {
+		dst := filepath.Join(dest, bin.name)
+		if err := copyFile(bin.src, dst); err != nil {
+			fmt.Fprintf(os.Stderr, "error installing %s to %s: %v\n", bin.name, dst, err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "installed %s\n", dst)
+	}
+}
+
+// copyFile copies src to dst with executable permissions.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
 // main executes KSOPS as an exec plugin
 func main() {
 	nargs := len(os.Args)
+
+	// Handle install subcommand
+	if nargs >= 2 && os.Args[1] == "install" {
+		installBinaries(os.Args[2:])
+		return
+	}
+
 	if !(nargs == 1 || nargs == 2) {
 		help()
 	}


### PR DESCRIPTION
Closes #300

Adding this approach over https://github.com/viaduct-ai/kustomize-sops/pull/303

Add a built-in install subcommand that copies ksops and kustomize
binaries to a target directory, removing the need for /bin/sh and
mv in the Docker image. This fixes the ArgoCD init container
integration broken since v4.4.0 when the image switched to
distroless.
