### PR TITLE
feat: concurrent secret decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Requirements](#requirements)
 - [Installation Options](#installation-options)
 - [Getting Started](#getting-started-tutorial)
+- [Configuration](#configuration)
 - [Generator Options](#generator-options)
 - [Development and Testing](#development-and-testing)
 - [Legacy Exec Plugin](#legacy-exec-plugin)
@@ -269,6 +270,29 @@ secretFrom:
   envs:
   - ./secret.enc.env
 EOF
+```
+
+## Configuration
+
+### Concurrent Decryption
+
+`KSOPS` decrypts files concurrently to improve performance when dealing with a large number of secrets. The maximum number of concurrent decryptions is controlled by the `KSOPS_CONCURRENCY_LIMIT` environment variable.
+
+```bash
+# Set the concurrency limit (default: 20)
+export KSOPS_CONCURRENCY_LIMIT=10
+kustomize build --enable-alpha-plugins --enable-exec .
+```
+
+If unset, the default concurrency limit is `20`. The value must be a positive integer.
+
+When using KSOPS with Argo CD, you can set this via the repo server environment variables:
+
+```yaml
+repoServer:
+  env:
+    - name: KSOPS_CONCURRENCY_LIMIT
+      value: "10"
 ```
 
 ## Generator Options

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,10 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-require github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20221109010843-1f7d0c07a381
+require (
+	github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20221109010843-1f7d0c07a381
+	golang.org/x/sync v0.19.0
+)
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -136,7 +139,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/ksops.go
+++ b/ksops.go
@@ -14,15 +14,42 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
 	"github.com/joho/godotenv"
+	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 )
+
+type keyData struct {
+	key  string
+	data []byte
+}
+
+// decryptAll concurrently decrypts a list of files using the provided errgroup,
+// returning results in the same order as the input.
+func decryptAll[T any](g *errgroup.Group, items []string, fn func(file string) (T, error)) ([]T, error) {
+	results := make([]T, len(items))
+	for i, file := range items {
+		g.Go(func() error {
+			v, err := fn(file)
+			if err != nil {
+				return err
+			}
+			results[i] = v
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
 
 type kubernetesSecret struct {
 	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`
@@ -142,14 +169,30 @@ func generate(raw []byte) (string, error) {
 		return "", fmt.Errorf("missing the required 'files' or 'secretFrom' key in the ksops manifests: %s", raw)
 	}
 
-	var output bytes.Buffer
+	var g errgroup.Group
+	limit := 20
+	if l := os.Getenv("KSOPS_CONCURRENCY_LIMIT"); l != "" {
+		limit, err = strconv.Atoi(l)
+		if err != nil || limit < 1 {
+			return "", fmt.Errorf("error parsing KSOPS_CONCURRENCY_LIMIT value %q: %w", l, err)
+		}
+	}
+	g.SetLimit(limit)
 
-	for i, file := range manifest.Files {
+	// Decrypt manifest.Files concurrently
+	decrypted, err := decryptAll(&g, manifest.Files, func(file string) ([]byte, error) {
 		data, err := decryptFile(file)
 		if err != nil {
-			return "", fmt.Errorf("error decrypting file %q from manifest.Files: %w", file, err)
+			return nil, fmt.Errorf("error decrypting file %q from manifest.Files: %w", file, err)
 		}
+		return data, nil
+	})
+	if err != nil {
+		return "", err
+	}
 
+	var output bytes.Buffer
+	for i, data := range decrypted {
 		output.Write(data)
 		// KRM treats will try parse (and fail) empty documents if there is a trailing separator
 		if i < (len(manifest.Files)+len(manifest.SecretFrom))-1 {
@@ -157,39 +200,55 @@ func generate(raw []byte) (string, error) {
 		}
 	}
 
-	for i, secretFrom := range manifest.SecretFrom {
+	for i, sf := range manifest.SecretFrom {
+		fileResults, err := decryptAll(&g, sf.Files, func(file string) (keyData, error) {
+			key, path := fileKeyPath(file)
+			data, err := decryptFile(path)
+			if err != nil {
+				return keyData{}, fmt.Errorf("error decrypting file %q from secretFrom.Files: %w", path, err)
+			}
+			return keyData{key: key, data: data}, nil
+		})
+		if err != nil {
+			return "", err
+		}
+
+		binaryResults, err := decryptAll(&g, sf.BinaryFiles, func(file string) (keyData, error) {
+			key, path := fileKeyPath(file)
+			data, err := decryptFile(path)
+			if err != nil {
+				return keyData{}, fmt.Errorf("error decrypting file %q from secretFrom.BinaryFiles: %w", path, err)
+			}
+			return keyData{key: key, data: data}, nil
+		})
+		if err != nil {
+			return "", err
+		}
+
+		envResults, err := decryptAll(&g, sf.Envs, func(file string) (keyData, error) {
+			data, err := decryptFile(file)
+			if err != nil {
+				return keyData{}, fmt.Errorf("error decrypting file %q from secretFrom.Envs: %w", file, err)
+			}
+			return keyData{key: file, data: data}, nil
+		})
+		if err != nil {
+			return "", err
+		}
+
 		stringData := make(map[string]string)
 		binaryData := make(map[string]string)
 
-		for _, file := range secretFrom.Files {
-			key, path := fileKeyPath(file)
-			data, err := decryptFile(path)
-			if err != nil {
-				return "", fmt.Errorf("error decrypting file %q from secretFrom.Files: %w", path, err)
-			}
-
-			stringData[key] = string(data)
+		for _, r := range fileResults {
+			stringData[r.key] = string(r.data)
 		}
-
-		for _, file := range secretFrom.BinaryFiles {
-			key, path := fileKeyPath(file)
-			data, err := decryptFile(path)
-			if err != nil {
-				return "", fmt.Errorf("error decrypting file %q from secretFrom.Files: %w", path, err)
-			}
-
-			binaryData[key] = base64.StdEncoding.EncodeToString(data)
+		for _, r := range binaryResults {
+			binaryData[r.key] = base64.StdEncoding.EncodeToString(r.data)
 		}
-
-		for _, file := range secretFrom.Envs {
-			data, err := decryptFile(file)
+		for _, r := range envResults {
+			env, err := godotenv.Unmarshal(string(r.data))
 			if err != nil {
-				return "", fmt.Errorf("error decrypting file %q from secretFrom.Envs: %w", file, err)
-			}
-
-			env, err := godotenv.Unmarshal(string(data))
-			if err != nil {
-				return "", fmt.Errorf("error unmarshalling .env file %q: %w", file, err)
+				return "", fmt.Errorf("error unmarshalling .env file %q: %w", r.key, err)
 			}
 			for k, v := range env {
 				stringData[k] = v
@@ -199,8 +258,8 @@ func generate(raw []byte) (string, error) {
 		s := kubernetesSecret{
 			APIVersion: "v1",
 			Kind:       "Secret",
-			Metadata:   secretFrom.Metadata,
-			Type:       secretFrom.Type,
+			Metadata:   sf.Metadata,
+			Type:       sf.Type,
 			StringData: stringData,
 			Data:       binaryData,
 		}

--- a/ksops_unit_test.go
+++ b/ksops_unit_test.go
@@ -1,0 +1,400 @@
+// Copyright 2019 viaduct.ai
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func importTestKey(t *testing.T) {
+	t.Helper()
+	keyPath := filepath.Join("test", "key.asc")
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Skipf("GPG test key not found at %s: %v", keyPath, err)
+	}
+	// Import silently; may already be imported
+	cmd := exec.Command("gpg", "--batch", "--import", keyPath)
+	cmd.Run()
+}
+
+func testFixturePath(t *testing.T, parts ...string) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join(parts...))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+	return abs
+}
+
+// makeManifest builds a ksops manifest YAML with absolute paths.
+func makeManifest(files []string, secretFrom ...string) []byte {
+	var b strings.Builder
+	b.WriteString("apiVersion: viaduct.ai/v1\nkind: ksops\nmetadata:\n  name: test\n")
+	if len(files) > 0 {
+		b.WriteString("files:\n")
+		for _, f := range files {
+			fmt.Fprintf(&b, "  - %s\n", f)
+		}
+	}
+	if len(secretFrom) > 0 {
+		b.WriteString(strings.Join(secretFrom, "\n"))
+		b.WriteString("\n")
+	}
+	return []byte(b.String())
+}
+
+// --- decryptAll tests (no SOPS needed) ---
+
+func TestDecryptAllOrderPreservation(t *testing.T) {
+	var g errgroup.Group
+	g.SetLimit(10)
+
+	items := []string{"a", "b", "c", "d", "e"}
+	results, err := decryptAll(&g, items, func(file string) (string, error) {
+		return "result-" + file, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != len(items) {
+		t.Fatalf("expected %d results, got %d", len(items), len(results))
+	}
+	for i, item := range items {
+		want := "result-" + item
+		if results[i] != want {
+			t.Errorf("results[%d] = %q, want %q", i, results[i], want)
+		}
+	}
+}
+
+func TestDecryptAllEmpty(t *testing.T) {
+	var g errgroup.Group
+	g.SetLimit(10)
+
+	results, err := decryptAll(&g, nil, func(file string) (string, error) {
+		t.Fatal("should not be called for nil input")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+
+	results, err = decryptAll(&g, []string{}, func(file string) (string, error) {
+		t.Fatal("should not be called for empty input")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestDecryptAllErrorPropagation(t *testing.T) {
+	var g errgroup.Group
+	g.SetLimit(10)
+
+	sentinel := errors.New("decrypt failed")
+	items := []string{"a", "b", "c"}
+	_, err := decryptAll(&g, items, func(file string) (string, error) {
+		if file == "b" {
+			return "", sentinel
+		}
+		return file, nil
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got: %v", err)
+	}
+}
+
+func TestDecryptAllConcurrency(t *testing.T) {
+	var g errgroup.Group
+	g.SetLimit(5)
+
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+
+	items := make([]string, 20)
+	for i := range items {
+		items[i] = fmt.Sprintf("file-%d", i)
+	}
+
+	results, err := decryptAll(&g, items, func(file string) (string, error) {
+		cur := running.Add(1)
+		// Track max concurrent goroutines
+		for {
+			old := maxRunning.Load()
+			if cur <= old || maxRunning.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		// Small yield to let other goroutines start
+		running.Add(-1)
+		return "done-" + file, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != len(items) {
+		t.Fatalf("expected %d results, got %d", len(items), len(results))
+	}
+	for i, item := range items {
+		if results[i] != "done-"+item {
+			t.Errorf("results[%d] = %q, want %q", i, results[i], "done-"+item)
+		}
+	}
+}
+
+// --- generate tests (require GPG key) ---
+
+func TestGenerateSingleFile(t *testing.T) {
+	importTestKey(t)
+
+	file := testFixturePath(t, "test", "legacy", "single", "secret.enc.yaml")
+	manifest := makeManifest([]string{file})
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	// The decrypted secret should contain these values
+	for _, want := range []string{"mysecret", "username", "password", "kustomize-sops"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateMultipleFiles(t *testing.T) {
+	importTestKey(t)
+
+	dir := testFixturePath(t, "test", "legacy", "multiple")
+	manifest := makeManifest([]string{
+		filepath.Join(dir, "secret-A.enc.yaml"),
+		filepath.Join(dir, "secret-B.enc.yaml"),
+		filepath.Join(dir, "secret-C.enc.yaml"),
+	})
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	// Should produce 3 documents separated by ---
+	docs := strings.Split(got, "---")
+	if len(docs) != 3 {
+		t.Errorf("expected 3 documents, got %d:\n%s", len(docs), got)
+	}
+
+	for _, name := range []string{"mysecret-A", "mysecret-B", "mysecret-C"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("output missing secret %q:\n%s", name, got)
+		}
+	}
+}
+
+func TestGenerateSecretFromFiles(t *testing.T) {
+	importTestKey(t)
+
+	file := testFixturePath(t, "test", "legacy", "file", "secret.enc.yaml")
+	manifest := makeManifest(nil, fmt.Sprintf(`secretFrom:
+- metadata:
+    name: mysecret
+  type: Opaque
+  files:
+  - %s`, file))
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	if !strings.Contains(got, "kind: Secret") {
+		t.Errorf("output missing 'kind: Secret':\n%s", got)
+	}
+	if !strings.Contains(got, "name: mysecret") {
+		t.Errorf("output missing 'name: mysecret':\n%s", got)
+	}
+	if !strings.Contains(got, "stringData:") {
+		t.Errorf("output missing 'stringData:':\n%s", got)
+	}
+}
+
+func TestGenerateSecretFromBinaryFiles(t *testing.T) {
+	importTestKey(t)
+
+	file := testFixturePath(t, "test", "legacy", "binaryfile", "secret.enc.yaml")
+	manifest := makeManifest(nil, fmt.Sprintf(`secretFrom:
+- metadata:
+    name: mysecret
+  type: Opaque
+  binaryFiles:
+  - %s`, file))
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	if !strings.Contains(got, "data:") {
+		t.Errorf("output missing 'data:':\n%s", got)
+	}
+	// Binary data should be base64 encoded
+	if !strings.Contains(got, "name: mysecret") {
+		t.Errorf("output missing 'name: mysecret':\n%s", got)
+	}
+}
+
+func TestGenerateSecretFromEnvs(t *testing.T) {
+	importTestKey(t)
+
+	file := testFixturePath(t, "test", "legacy", "envs", "secret.enc.env")
+	manifest := makeManifest(nil, fmt.Sprintf(`secretFrom:
+- metadata:
+    name: mysecret
+  envs:
+  - %s`, file))
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	if !strings.Contains(got, "name: mysecret") {
+		t.Errorf("output missing 'name: mysecret':\n%s", got)
+	}
+	if !strings.Contains(got, "username:") {
+		t.Errorf("output missing 'username:':\n%s", got)
+	}
+	if !strings.Contains(got, "password:") {
+		t.Errorf("output missing 'password:':\n%s", got)
+	}
+}
+
+func TestGenerateFilesAndSecretFrom(t *testing.T) {
+	importTestKey(t)
+
+	dir := testFixturePath(t, "test", "legacy", "multiple")
+	file := filepath.Join(dir, "secret.enc.yaml")
+	manifest := makeManifest(
+		[]string{
+			filepath.Join(dir, "secret-A.enc.yaml"),
+		},
+		fmt.Sprintf(`secretFrom:
+- metadata:
+    name: mysecret
+  type: Opaque
+  binaryFiles:
+  - %s`, file),
+	)
+
+	got, err := generate(manifest)
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	// Should have both: the decrypted file and the constructed secret
+	docs := strings.Split(got, "---")
+	if len(docs) != 2 {
+		t.Errorf("expected 2 documents, got %d:\n%s", len(docs), got)
+	}
+}
+
+// --- concurrency limit tests ---
+
+func TestConcurrencyLimitEnvVar(t *testing.T) {
+	importTestKey(t)
+
+	file := testFixturePath(t, "test", "legacy", "single", "secret.enc.yaml")
+	manifest := makeManifest([]string{file})
+
+	t.Run("valid limit", func(t *testing.T) {
+		t.Setenv("KSOPS_CONCURRENCY_LIMIT", "5")
+		_, err := generate(manifest)
+		if err != nil {
+			t.Fatalf("generate failed with valid limit: %v", err)
+		}
+	})
+
+	t.Run("invalid non-numeric", func(t *testing.T) {
+		t.Setenv("KSOPS_CONCURRENCY_LIMIT", "abc")
+		_, err := generate(manifest)
+		if err == nil {
+			t.Fatal("expected error for non-numeric limit")
+		}
+		if !strings.Contains(err.Error(), "KSOPS_CONCURRENCY_LIMIT") {
+			t.Errorf("error should mention KSOPS_CONCURRENCY_LIMIT: %v", err)
+		}
+	})
+
+	t.Run("invalid zero", func(t *testing.T) {
+		t.Setenv("KSOPS_CONCURRENCY_LIMIT", "0")
+		_, err := generate(manifest)
+		if err == nil {
+			t.Fatal("expected error for zero limit")
+		}
+	})
+
+	t.Run("invalid negative", func(t *testing.T) {
+		t.Setenv("KSOPS_CONCURRENCY_LIMIT", "-1")
+		_, err := generate(manifest)
+		if err == nil {
+			t.Fatal("expected error for negative limit")
+		}
+	})
+
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("KSOPS_CONCURRENCY_LIMIT", "")
+		_, err := generate(manifest)
+		if err != nil {
+			t.Fatalf("generate failed with default limit: %v", err)
+		}
+	})
+}
+
+func TestGenerateErrors(t *testing.T) {
+	t.Run("missing files and secretFrom", func(t *testing.T) {
+		manifest := []byte(`apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: test
+`)
+		_, err := generate(manifest)
+		if err == nil {
+			t.Fatal("expected error for missing files and secretFrom")
+		}
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		_, err := generate([]byte(`{invalid`))
+		if err == nil {
+			t.Fatal("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		manifest := makeManifest([]string{"/nonexistent/file.yaml"})
+		_, err := generate(manifest)
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}


### PR DESCRIPTION
Implements https://github.com/viaduct-ai/kustomize-sops/pull/301

> ksops can be too slow when each decrypt is slow and there are a large numbers of secrets. This uses an errgroup with a configurable limit to help.

Makes secret decryption faster via concurrency.
